### PR TITLE
Header: Link back to Ello root

### DIFF
--- a/src/components/TopNav/LogoTitle.js
+++ b/src/components/TopNav/LogoTitle.js
@@ -51,14 +51,14 @@ const Text = styled.span`
 
 const renderWithLink = () => (
   <TitleHolder title="Ello">
-    <Link to="/">
+    <a href="/" title="Back to Ello">
       <Logo>
         <ElloLogo />
       </Logo>
       <Text>
         Ello
       </Text>
-    </Link>
+    </a>
   </TitleHolder>
 )
 


### PR DESCRIPTION
Once in `staging` realized that `to="/"` in the `Link` component only sends us back to the root of the app, not the domain.

https://www.pivotaltracker.com/story/show/152292733