### PR TITLE
Don't use expired tokens like they are valid.

### DIFF
--- a/src/sagas/auth.js
+++ b/src/sagas/auth.js
@@ -46,7 +46,7 @@ function* rehydrateSaga() {
       const expiresAt = payload.auth.get('expiresAt')
 
       // Prefer existing, valid token.
-      if (accessToken && (expiresAt * 1000 > Date.now())) {
+      if (accessToken && (expiresAt > Date.now())) {
         yield put(bootstrapSuccess({ accessToken, refreshToken, expiresAt }))
       // Secondary is valid refresh token.
       } else if (refreshToken) {


### PR DESCRIPTION
This should fix the most common authentication error. However there are
a lot of situations we handle poorly. We don't do anything if a token
expires when you are browsing, something we should probably fix but is
a bit of a race condition. Fixing is a bigger task.